### PR TITLE
stochastic reference search

### DIFF
--- a/MemoryCrawler/MemoryCrawler/Crawler/crawler.cpp
+++ b/MemoryCrawler/MemoryCrawler/Crawler/crawler.cpp
@@ -895,8 +895,11 @@ vector<vector<int32_t>> MemorySnapshotCrawler::iterateMStochasticRefChain(Manage
     {
         set<int64_t> unique;
 
-        int connectionCount = mo->fromConnections.size();
-        for(auto currentStaochasticCount = 0; currentStaochasticCount < connectionCount; ++currentStaochasticCount)
+        int stochasticTryCount = mo->fromConnections.size();
+        if(__depth == 0 && limit > 0) 
+            stochasticTryCount *= limit;
+            
+        for(auto currentStaochasticCount = 0; currentStaochasticCount < stochasticTryCount; ++currentStaochasticCount)
         {
             if(reachRootStatus == ReachRootStatus::DuplicateReach || reachRootStatus == ReachRootStatus::FirstReach)
             {

--- a/MemoryCrawler/MemoryCrawler/Crawler/crawler.cpp
+++ b/MemoryCrawler/MemoryCrawler/Crawler/crawler.cpp
@@ -394,7 +394,7 @@ void MemorySnapshotCrawler::trackNTypeObjects(MemoryState state, int32_t typeInd
     printf("\e[37m[SUMMARY] total_count=%d memory=%d\n", count, total);
 }
 
-void MemorySnapshotCrawler::barMMemory(MemoryState state, int32_t rank)
+void MemorySnapshotCrawler::barMMemory(MemoryState state, bool sortByCount, int32_t rank)
 {
     double totalMemory = 0;
     vector<int32_t> indice;
@@ -426,8 +426,18 @@ void MemorySnapshotCrawler::barMMemory(MemoryState state, int32_t rank)
               {
                   auto ma = typeMemory[a];
                   auto mb = typeMemory[b];
-                  if (ma != mb) {return ma > mb;}
-                  return typeCount.at(a) < typeCount.at(b);
+                  auto ca = typeCount.at(a);
+                  auto cb = typeCount.at(b);
+                  if(!sortByCount)
+                  {
+                    if (ma != mb) {return ma > mb;}
+                    return ca < cb;
+                  }
+                  else
+                  {
+                    if (ca != cb) {return ca > cb;}
+                    return ma < mb;
+                  }
               });
     
     vector<std::tuple<int32_t, double, double>> stats;
@@ -464,7 +474,7 @@ void MemorySnapshotCrawler::barMMemory(MemoryState state, int32_t rank)
     }
 }
 
-void MemorySnapshotCrawler::barNMemory(MemoryState state, int32_t rank)
+void MemorySnapshotCrawler::barNMemory(MemoryState state, bool sortByCount, int32_t rank)
 {
     double totalMemory = 0;
     vector<int32_t> indice;
@@ -497,8 +507,18 @@ void MemorySnapshotCrawler::barNMemory(MemoryState state, int32_t rank)
               {
                   auto ma = typeMemory[a];
                   auto mb = typeMemory[b];
-                  if (ma != mb) {return ma > mb;}
-                  return typeCount.at(a) < typeCount.at(b);
+                  auto ca = typeCount.at(a);
+                  auto cb = typeCount.at(b);
+                  if(!sortByCount)
+                  {
+                    if (ma != mb) {return ma > mb;}
+                    return ca < cb;
+                  }
+                  else
+                  {
+                    if (ca != cb) {return ca > cb;}
+                    return ma < mb;
+                  }
               });
     
     vector<std::tuple<int32_t, double, double>> stats;

--- a/MemoryCrawler/MemoryCrawler/Crawler/crawler.h
+++ b/MemoryCrawler/MemoryCrawler/Crawler/crawler.h
@@ -170,9 +170,10 @@ public:
     void dumpNObjectHierarchy(PackedNativeUnityEngineObject *no,
                               set<int64_t> antiCircular, int32_t limit, const char *indent, int32_t __iter_depth = 0, int32_t __iter_capacity = 1);
     
-    void barMMemory(MemoryState state, int32_t rank = 20);
-    void barNMemory(MemoryState state, int32_t rank = 20);
+    void barMMemory(MemoryState state, bool sortByCount = false, int32_t rank = 20);
+    void barNMemory(MemoryState state, bool sortByCount = false, int32_t rank = 20);
     
+
     void statHeap(int32_t rank = 20);
     
     void dumpVRefChain(address_t address);

--- a/MemoryCrawler/MemoryCrawler/Crawler/crawler.h
+++ b/MemoryCrawler/MemoryCrawler/Crawler/crawler.h
@@ -103,6 +103,8 @@ public:
     
     PackedMemorySnapshot snapshot;
     
+    enum ReachRootStatus { Init = 0, FirstReach, DuplicateReach };
+
 private:
     static constexpr int64_t REF_ITERATE_CAPACITY = 1 << 20;
     static constexpr int32_t REF_ITERATE_DEPTH = 32;
@@ -174,12 +176,15 @@ public:
     void statHeap(int32_t rank = 20);
     
     void dumpVRefChain(address_t address);
-    void dumpMRefChain(address_t address, bool includeCircular, int32_t limit = 2);
+    void dumpMRefChain(address_t address, bool includeCircular, bool stochastic, int32_t limit = 2);
     void dumpNRefChain(address_t address, bool includeCircular, int32_t limit = 2);
     vector<vector<int32_t>> iterateNRefChain(PackedNativeUnityEngineObject *no,
                                              vector<int32_t> chain, set<int64_t> antiCircular, int32_t limit = 2, int64_t __iter_capacity = 1, int32_t __depth = 0);
     vector<vector<int32_t>> iterateMRefChain(ManagedObject *mo,
                                              vector<int32_t> chain, set<int64_t> antiCircular, int32_t limit = 2, int64_t __iter_capacity = 1, int32_t __depth = 0);
+    vector<vector<int32_t>> iterateMStochasticRefChain(ManagedObject *mo,
+                                             vector<int32_t> chain, set<int64_t> antiCircular, set<int64_t>& reachedRoot, ReachRootStatus& reachRootStatus, int32_t limit = 2, int64_t __iter_capacity = 1, int32_t __depth = 0);
+    
     
     address_t findMObjectOfNObject(address_t address);
     address_t findNObjectOfMObject(address_t address);

--- a/MemoryCrawler/MemoryCrawler/main.cpp
+++ b/MemoryCrawler/MemoryCrawler/main.cpp
@@ -157,7 +157,18 @@ void processRecord(const char * filepath)
                                    for (auto i = 1; i < options.size(); i++)
                                    {
                                        auto address = castAddress(options[i]);
-                                       mainCrawler.dumpMRefChain(address, false, -1);
+                                       mainCrawler.dumpMRefChain(address, false, false, -1);
+                                   }
+                               });
+        }
+        else if (strbeg(command, "KSREF")) // complete managed object reference chains except circular ones
+        {
+            readCommandOptions(command, [&](std::vector<const char *> &options)
+                               {
+                                   for (auto i = 1; i < options.size(); i++)
+                                   {
+                                       auto address = castAddress(options[i]);
+                                       mainCrawler.dumpMRefChain(address, false, true, -1);
                                    }
                                });
         }
@@ -179,7 +190,18 @@ void processRecord(const char * filepath)
                                    for (auto i = 1; i < options.size(); i++)
                                    {
                                        auto address = castAddress(options[i]);
-                                       mainCrawler.dumpMRefChain(address, true, -1);
+                                       mainCrawler.dumpMRefChain(address, true, false, -1);
+                                   }
+                               });
+        }
+        else if (strbeg(command, "SREF")) // complete managed object reference chains
+        {
+            readCommandOptions(command, [&](std::vector<const char *> &options)
+                               {
+                                   for (auto i = 1; i < options.size(); i++)
+                                   {
+                                       auto address = castAddress(options[i]);
+                                       mainCrawler.dumpMRefChain(address, true, true, -1);
                                    }
                                });
         }
@@ -200,7 +222,17 @@ void processRecord(const char * filepath)
                                {
                                    if (options.size() >= 2)
                                    {
-                                       mainCrawler.dumpMRefChain(castAddress(options[1]), false, options.size() >= 3 ? atoi(options[2]) : 2);
+                                       mainCrawler.dumpMRefChain(castAddress(options[1]), false, false, options.size() >= 3 ? atoi(options[2]) : 2);
+                                   }
+                               });
+        }
+        else if (strbeg(command, "ksref")) // partial managed object reference chains except circular ones
+        {
+            readCommandOptions(command, [&](std::vector<const char *> &options)
+                               {
+                                   if (options.size() >= 2)
+                                   {
+                                       mainCrawler.dumpMRefChain(castAddress(options[1]), false, true, options.size() >= 3 ? atoi(options[2]) : 2);
                                    }
                                });
         }
@@ -220,7 +252,17 @@ void processRecord(const char * filepath)
                                {
                                    if (options.size() >= 2)
                                    {
-                                       mainCrawler.dumpMRefChain(castAddress(options[1]), true, options.size() >= 3 ? atoi(options[2]) : 2);
+                                       mainCrawler.dumpMRefChain(castAddress(options[1]), true, false, options.size() >= 3 ? atoi(options[2]) : 2);
+                                   }
+                               });
+        }
+        else if (strbeg(command, "sref")) // partial managed object reference chains
+        {
+            readCommandOptions(command, [&](std::vector<const char *> &options)
+                               {
+                                   if (options.size() >= 2)
+                                   {
+                                       mainCrawler.dumpMRefChain(castAddress(options[1]), true, true, options.size() >= 3 ? atoi(options[2]) : 2);
                                    }
                                });
         }

--- a/MemoryCrawler/MemoryCrawler/main.cpp
+++ b/MemoryCrawler/MemoryCrawler/main.cpp
@@ -480,13 +480,13 @@ void processRecord(const char * filepath)
                                {
                                    if (options.size() == 1)
                                    {
-                                       mainCrawler.barMMemory(trackingMode, 20);
+                                       mainCrawler.barMMemory(trackingMode, false, 20);
                                    }
                                    else
                                    {
                                        for (auto i = 1; i < options.size(); i++)
                                        {
-                                           mainCrawler.barMMemory(trackingMode, atoi(options[i]));
+                                           mainCrawler.barMMemory(trackingMode, false, atoi(options[i]));
                                        }
                                    }
                                });
@@ -497,13 +497,47 @@ void processRecord(const char * filepath)
                                {
                                    if (options.size() == 1)
                                    {
-                                       mainCrawler.barNMemory(trackingMode, 20);
+                                       mainCrawler.barNMemory(trackingMode, false, 20);
                                    }
                                    else
                                    {
                                        for (auto i = 1; i < options.size(); i++)
                                        {
-                                           mainCrawler.barNMemory(trackingMode, atoi(options[i]));
+                                           mainCrawler.barNMemory(trackingMode, false, atoi(options[i]));
+                                       }
+                                   }
+                               });
+        }
+        else if (strbeg(command, "barcount"))
+        {
+            readCommandOptions(command, [&](std::vector<const char *> options)
+                               {
+                                   if (options.size() == 1)
+                                   {
+                                       mainCrawler.barMMemory(trackingMode, true, 20);
+                                   }
+                                   else
+                                   {
+                                       for (auto i = 1; i < options.size(); i++)
+                                       {
+                                           mainCrawler.barMMemory(trackingMode, true, atoi(options[i]));
+                                       }
+                                   }
+                               });
+        }
+        else if (strbeg(command, "ubarcount"))
+        {
+            readCommandOptions(command, [&](std::vector<const char *> options)
+                               {
+                                   if (options.size() == 1)
+                                   {
+                                       mainCrawler.barNMemory(trackingMode, true, 20);
+                                   }
+                                   else
+                                   {
+                                       for (auto i = 1; i < options.size(); i++)
+                                       {
+                                           mainCrawler.barNMemory(trackingMode, true, atoi(options[i]));
                                        }
                                    }
                                });


### PR DESCRIPTION
`kref` tends to search one root at a time. If the search budget is limited but the reference graph is complicated, the reported reference chains usually show 1 gc root with trivial different chains.

```
\> kref 0x12b9fb1c0
<GCHandle>::OneRootA 0x124706240
...
    . theSearchTarget 0x12b9fb1c0

<GCHandle>::OneRootA 0x124706240
...
    . theSearchTarget 0x12b9fb1c0

<GCHandle>::OneRootA 0x124706240
...
    . theSearchTarget 0x12b9fb1c0

...
```

this pull request adds `ksref`, which uses stochastic-like graph search. In the same circumstance, it prefers to search different root, stochastically.

```
/> ksref 0x12b9fb1c0
<GCHandle>::OneRootA 0x124706240
...
    . theSearchTarget 0x12b9fb1c0

<Static>::OneRootB 0x12418b660
...
    . theSearchTarget 0x12b9fb1c0
```


**This should improve our productivity to find multiple reference leaks in complicated reference graph.**
